### PR TITLE
feat: Replace 'Sin planificar' with engaging meal slot CTAs

### DIFF
--- a/client/src/components/weekly-calendar.tsx
+++ b/client/src/components/weekly-calendar.tsx
@@ -128,8 +128,16 @@ export function WeeklyCalendar({ onAddMeal, onViewMealPlan }: WeeklyCalendarProp
           ))}
         </div>
       ) : (
-        <div className="p-4 border-2 border-dashed border-gray-200 rounded-lg text-center">
-          <p className="text-xs text-gray-400">Sin planificar</p>
+        <div 
+          className="p-4 border-2 border-dashed border-gray-200 rounded-lg text-center cursor-pointer hover:border-app-accent hover:bg-orange-50/50 transition-all group"
+          onClick={() => onAddMeal(formatDate(date), mealType)}
+        >
+          <div className="flex flex-col items-center space-y-1">
+            <Plus className="w-4 h-4 text-gray-300 group-hover:text-app-accent transition-colors" />
+            <p className="text-xs text-gray-400 group-hover:text-app-accent transition-colors">
+              {mealType === 'almuerzo' ? 'Agregar almuerzo' : 'Agregar cena'}
+            </p>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replaces generic "Sin planificar" text with contextual CTAs
- Adds "Agregar almuerzo" / "Agregar cena" based on meal type  
- Makes entire empty slot clickable for better UX
- Includes hover animations with orange accent colors

## Before & After
**Before**: Generic "Sin planificar" text
**After**: Engaging "Agregar almuerzo" / "Agregar cena" with icons and hover states

## Test Plan
- [x] Verify empty lunch slots show "Agregar almuerzo"
- [x] Verify empty dinner slots show "Agregar cena"  
- [x] Confirm clicking empty slots opens meal selection modal
- [x] Test hover animations and color transitions
- [x] Validate on both mobile and desktop layouts

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)