### PR TITLE
Fix meal plan date shifting caused by timezone conversion

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -6,7 +6,10 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatDate(date: Date): string {
-  return date.toISOString().split('T')[0];
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 export function getWeekDates(startDate: Date): Date[] {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -230,7 +230,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const dayOfWeek = today.getDay();
         const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1); // Monday
         startOfWeek.setDate(diff);
-        mealPlans = await storage.getMealPlansForWeek(startOfWeek.toISOString().split('T')[0]);
+        // Format date correctly in local timezone
+        const year = startOfWeek.getFullYear();
+        const month = String(startOfWeek.getMonth() + 1).padStart(2, '0');
+        const day = String(startOfWeek.getDate()).padStart(2, '0');
+        const formattedDate = `${year}-${month}-${day}`;
+        mealPlans = await storage.getMealPlansForWeek(formattedDate);
       }
       
       res.json(mealPlans);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -249,10 +249,16 @@ export class DatabaseStorage implements IStorage {
     const end = new Date(start);
     end.setDate(start.getDate() + 6);
     
+    // Format end date correctly in local timezone
+    const year = end.getFullYear();
+    const month = String(end.getMonth() + 1).padStart(2, '0');
+    const day = String(end.getDate()).padStart(2, '0');
+    const endDateStr = `${year}-${month}-${day}`;
+    
     return await db.select().from(mealPlans).where(
       and(
         gte(mealPlans.fecha, startDate),
-        lte(mealPlans.fecha, end.toISOString().split('T')[0])
+        lte(mealPlans.fecha, endDateStr)
       )
     );
   }


### PR DESCRIPTION
## Summary
- Fixed a critical bug where meal plans were displaying one day earlier than scheduled
- Replaced UTC date conversion with local timezone formatting throughout the application
- Ensures consistent date handling across frontend and backend components

## Problem
The application was using `toISOString()` to format dates, which converts to UTC time. For users in timezones behind UTC (like Argentina at UTC-3), this would shift dates backward by one day, causing Monday's meal plan to appear on Sunday, Tuesday's on Monday, etc.

## Solution
- Updated `formatDate()` utility to use local date components (getFullYear, getMonth, getDate)
- Fixed server-side date calculations to maintain local timezone
- Modified database storage layer to format dates correctly

## Test Plan
- [x] Verified meal plans display on correct days of the week
- [x] Tested week navigation maintains proper date alignment
- [x] Confirmed Friday August 22nd shows as "VIE 22" with correct meals

🤖 Generated with [Claude Code](https://claude.ai/code)