### PR TITLE
fix: conversation history cap for catalog context

### DIFF
--- a/server/__tests__/recipe-assistant.test.ts
+++ b/server/__tests__/recipe-assistant.test.ts
@@ -166,16 +166,16 @@ describe('validateConversationHistory', () => {
     expect(result[0].content).toBe('Valid');
   });
 
-  it('filters out messages with content exceeding 10000 chars', () => {
+  it('filters out messages with content exceeding 30000 chars', () => {
     const history = [
       { role: 'user' as const, content: 'Short message' },
-      { role: 'user' as const, content: 'A'.repeat(10001) },
-      { role: 'assistant' as const, content: 'A'.repeat(10000) }, // exactly at limit
+      { role: 'user' as const, content: 'A'.repeat(30001) },
+      { role: 'assistant' as const, content: 'A'.repeat(30000) }, // exactly at limit
     ];
     const result = validateConversationHistory(history);
     expect(result).toHaveLength(2);
     expect(result[0].content).toBe('Short message');
-    expect(result[1].content).toHaveLength(10000);
+    expect(result[1].content).toHaveLength(30000);
   });
 
   it('caps at MAX_CONVERSATION_TURNS * 2 messages (20)', () => {

--- a/server/services/recipe-assistant.ts
+++ b/server/services/recipe-assistant.ts
@@ -188,7 +188,7 @@ export function validateConversationHistory(history: unknown): ConversationMessa
       typeof msg === 'object' &&
       (msg.role === 'user' || msg.role === 'assistant') &&
       typeof msg.content === 'string' &&
-      msg.content.length <= 10000 // Cap individual message size
+      msg.content.length <= 30000 // Cap individual message size (catalog message is ~20k)
     )
     .map(msg => ({ role: msg.role, content: msg.content })); // Strip any extra fields
 }


### PR DESCRIPTION
## Summary
- Increases per-message validation cap from 10k to 30k characters
- The enriched recipe catalog (~20k chars) was being silently stripped during refinement, causing the LLM to lose recipe context

Fixes the "No tengo acceso a la lista de recetas" error on refinement requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)