### PR TITLE
feat: weekly meal plan review workflow (submit + email)

### DIFF
--- a/client/src/components/weekly-calendar.tsx
+++ b/client/src/components/weekly-calendar.tsx
@@ -1,13 +1,25 @@
 import { useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight, Calendar, MessageCircle } from "lucide-react";
+import { ChevronLeft, ChevronRight, Calendar, MessageCircle, Send, CheckCircle2 } from "lucide-react";
 import { AddMealButton } from "@/components/add-meal-button";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useQuery } from "@tanstack/react-query";
 import { formatWeekRange, formatEnhancedWeekRange, getMonday, getDayName, formatDate, getWeekDates } from "@/lib/utils";
 import type { MealPlan, Recipe } from "@shared/schema";
 import { useMealAchievements } from "@/hooks/use-meal-achievements";
 import { MealCommentSheet } from "@/components/meal-comment-sheet";
+import { CreatorOnly } from "@/components/role-based-wrapper";
+import { useWeeklyReview } from "@/hooks/use-weekly-review";
 
 interface WeeklyCalendarProps {
   onAddMeal: (date: string, mealType: string) => void;
@@ -22,6 +34,10 @@ export function WeeklyCalendar({ onAddMeal, onViewMealPlan }: WeeklyCalendarProp
     recipeId: number;
     recipeName: string;
   } | null>(null);
+  const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
+
+  const weekStartStr = formatDate(currentWeekStart);
+  const { review, submit: submitReview, isSubmitting } = useWeeklyReview(weekStartStr);
 
   const { data: mealPlans, isLoading } = useQuery({
     queryKey: ["/api/meal-plans", { startDate: formatDate(currentWeekStart) }],
@@ -305,6 +321,39 @@ export function WeeklyCalendar({ onAddMeal, onViewMealPlan }: WeeklyCalendarProp
           )}
         </div>
         
+        {/* Review status + submit action */}
+        <div className="flex items-center justify-between gap-2 mt-2 mb-1">
+          {review ? (
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 border border-emerald-200 px-2.5 py-1 rounded-full">
+              <CheckCircle2 className="w-3.5 h-3.5" />
+              Enviada para revisión
+            </span>
+          ) : (
+            <span className="text-xs text-slate-500">
+              {mealPlans && mealPlans.length > 0
+                ? `${mealPlans.length} comida${mealPlans.length === 1 ? "" : "s"} planeada${mealPlans.length === 1 ? "" : "s"}`
+                : "Sin comidas planeadas"}
+            </span>
+          )}
+
+          <CreatorOnly>
+            <Button
+              variant={review ? "outline" : "default"}
+              size="sm"
+              onClick={() => setShowSubmitConfirm(true)}
+              disabled={isSubmitting || (mealPlans?.length ?? 0) === 0}
+              className={
+                review
+                  ? "text-xs border-slate-300 text-slate-700 hover:bg-slate-100"
+                  : "text-xs bg-app-accent hover:bg-app-accent/90 text-slate-900 font-medium"
+              }
+            >
+              <Send className="w-3.5 h-3.5 mr-1.5" />
+              {review ? "Reenviar" : "Enviar para revisión"}
+            </Button>
+          </CreatorOnly>
+        </div>
+
         {/* Keyboard navigation hint - hidden on mobile */}
         <div className="text-center hidden md:block">
           <p className="text-xs text-slate-600/70 font-medium">
@@ -462,6 +511,35 @@ export function WeeklyCalendar({ onAddMeal, onViewMealPlan }: WeeklyCalendarProp
         isOpen={!!commentSheetMeal}
         onClose={() => setCommentSheetMeal(null)}
       />
+
+      {/* Submit for review confirmation */}
+      <AlertDialog open={showSubmitConfirm} onOpenChange={setShowSubmitConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {review ? "¿Reenviar esta semana para revisión?" : "¿Enviar esta semana para revisión?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Se enviará un email al resto de la familia avisándoles que pueden revisar el menú de la semana del{" "}
+              {formatEnhancedWeekRange(currentWeekStart).range} y dejar sus comentarios.
+              {review && " La revisión anterior será reemplazada."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSubmitting}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSubmitting}
+              onClick={() => {
+                submitReview();
+                setShowSubmitConfirm(false);
+              }}
+              className="bg-app-accent hover:bg-app-accent/90 text-slate-900"
+            >
+              {review ? "Reenviar" : "Enviar"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/components/weekly-calendar.tsx
+++ b/client/src/components/weekly-calendar.tsx
@@ -14,6 +14,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useQuery } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { es } from "date-fns/locale";
 import { formatWeekRange, formatEnhancedWeekRange, getMonday, getDayName, formatDate, getWeekDates } from "@/lib/utils";
 import type { MealPlan, Recipe } from "@shared/schema";
 import { useMealAchievements } from "@/hooks/use-meal-achievements";
@@ -324,9 +326,12 @@ export function WeeklyCalendar({ onAddMeal, onViewMealPlan }: WeeklyCalendarProp
         {/* Review status + submit action */}
         <div className="flex items-center justify-between gap-2 mt-2 mb-1">
           {review ? (
-            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 border border-emerald-200 px-2.5 py-1 rounded-full">
+            <span
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 border border-emerald-200 px-2.5 py-1 rounded-full"
+              title={`Enviada el ${new Date(review.submittedAt).toLocaleString("es-AR")}`}
+            >
               <CheckCircle2 className="w-3.5 h-3.5" />
-              Enviada para revisión
+              Enviada {formatDistanceToNow(new Date(review.submittedAt), { addSuffix: true, locale: es })}
             </span>
           ) : (
             <span className="text-xs text-slate-500">

--- a/client/src/hooks/use-weekly-review.ts
+++ b/client/src/hooks/use-weekly-review.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
+import { jsonApiRequest } from "@/lib/queryClient";
+
+export interface WeeklyReview {
+  id: number;
+  familyId: number;
+  weekStartDate: string;
+  status: string;
+  submittedBy: number;
+  submittedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function useWeeklyReview(weekStartDate: string | undefined) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const reviewQuery = useQuery<WeeklyReview | null>({
+    queryKey: ["weekly-review", weekStartDate],
+    queryFn: async () => {
+      if (!weekStartDate) return null;
+      return await jsonApiRequest<WeeklyReview | null>(
+        `/api/weekly-reviews?weekStartDate=${encodeURIComponent(weekStartDate)}`
+      );
+    },
+    enabled: !!weekStartDate,
+    staleTime: 30 * 1000,
+    retry: false,
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: async (): Promise<WeeklyReview> => {
+      if (!weekStartDate) throw new Error("No se seleccionó una semana");
+      return await jsonApiRequest<WeeklyReview>("/api/weekly-reviews", {
+        method: "POST",
+        body: JSON.stringify({ weekStartDate }),
+      });
+    },
+    onSuccess: () => {
+      toast({ title: "Semana enviada para revisión ✉️" });
+      queryClient.invalidateQueries({ queryKey: ["weekly-review", weekStartDate] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Error al enviar para revisión",
+        description: error.message || "Inténtalo de nuevo.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  return {
+    review: reviewQuery.data ?? null,
+    isLoading: reviewQuery.isLoading,
+    submit: submitMutation.mutate,
+    isSubmitting: submitMutation.isPending,
+  };
+}

--- a/server/__tests__/email.test.ts
+++ b/server/__tests__/email.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock Resend at module level — vi.mock is hoisted
+const mockSend = vi.fn();
+vi.mock("resend", () => {
+  return {
+    Resend: class MockResend {
+      emails = { send: mockSend };
+    },
+  };
+});
+
+describe("sendWeekReviewNotification", () => {
+  const originalKey = process.env.RESEND_API_KEY;
+  let sendWeekReviewNotification: typeof import("../email").sendWeekReviewNotification;
+
+  beforeEach(async () => {
+    mockSend.mockReset();
+    mockSend.mockResolvedValue({ data: { id: "test-id" }, error: null });
+    process.env.RESEND_API_KEY = "test-key";
+    // Re-import with the env var set so `resend` gets initialized
+    vi.resetModules();
+    const mod = await import("../email");
+    sendWeekReviewNotification = mod.sendWeekReviewNotification;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.RESEND_API_KEY;
+    } else {
+      process.env.RESEND_API_KEY = originalKey;
+    }
+  });
+
+  it("sends one email per opted-in recipient", async () => {
+    sendWeekReviewNotification({
+      familyName: "Familia Tourn",
+      weekStartDate: "2026-04-20",
+      submitterName: "Lucho",
+      recipients: [
+        { email: "kid1@example.com", name: "Kid 1", notificationPreferences: null },
+        { email: "kid2@example.com", name: "Kid 2", notificationPreferences: null },
+      ],
+    });
+
+    // Wait a microtask for any fire-and-forget promise chains
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const calls = mockSend.mock.calls.map((c) => c[0]);
+    expect(calls[0].to).toBe("kid1@example.com");
+    expect(calls[1].to).toBe("kid2@example.com");
+    expect(calls[0].subject).toContain("20/04");
+    expect(calls[0].text).toContain("Lucho");
+    expect(calls[0].text).toContain("Kid 1");
+    expect(calls[0].text).toContain("Familia Tourn");
+  });
+
+  it("skips recipients who opted out of email notifications", async () => {
+    sendWeekReviewNotification({
+      familyName: "Familia Tourn",
+      weekStartDate: "2026-04-20",
+      submitterName: "Lucho",
+      recipients: [
+        {
+          email: "optedout@example.com",
+          name: "Opted Out",
+          notificationPreferences: JSON.stringify({ email: false, mealPlans: true }),
+        },
+        {
+          email: "in@example.com",
+          name: "In",
+          notificationPreferences: JSON.stringify({ email: true, mealPlans: true }),
+        },
+      ],
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSend.mock.calls[0][0].to).toBe("in@example.com");
+  });
+
+  it("skips recipients who opted out of meal-plan notifications", async () => {
+    sendWeekReviewNotification({
+      familyName: "Familia Tourn",
+      weekStartDate: "2026-04-20",
+      submitterName: "Lucho",
+      recipients: [
+        {
+          email: "optedout@example.com",
+          name: "Opted Out",
+          notificationPreferences: JSON.stringify({ email: true, mealPlans: false }),
+        },
+      ],
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("treats malformed preferences as opted-in (fail-open)", async () => {
+    sendWeekReviewNotification({
+      familyName: "Familia Tourn",
+      weekStartDate: "2026-04-20",
+      submitterName: "Lucho",
+      recipients: [
+        {
+          email: "malformed@example.com",
+          name: "Malformed",
+          notificationPreferences: "not-valid-json{",
+        },
+      ],
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends nothing when no recipients are given", async () => {
+    sendWeekReviewNotification({
+      familyName: "Familia Tourn",
+      weekStartDate: "2026-04-20",
+      submitterName: "Lucho",
+      recipients: [],
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when RESEND_API_KEY is not set", async () => {
+    delete process.env.RESEND_API_KEY;
+    vi.resetModules();
+    const { sendWeekReviewNotification: freshSender } = await import("../email");
+
+    freshSender({
+      familyName: "Familia Tourn",
+      weekStartDate: "2026-04-20",
+      submitterName: "Lucho",
+      recipients: [
+        { email: "kid@example.com", name: "Kid", notificationPreferences: null },
+      ],
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/server/email.ts
+++ b/server/email.ts
@@ -4,6 +4,8 @@ const resend = process.env.RESEND_API_KEY
   ? new Resend(process.env.RESEND_API_KEY)
   : null;
 
+const FROM_ADDRESS = "Menu Semanal <notificaciones@menusemanal.app>";
+
 export function sendSignupNotification(email: string, source: string): void {
   if (!resend || !process.env.NOTIFY_EMAIL) {
     console.log("Email notification skipped (RESEND_API_KEY or NOTIFY_EMAIL not set)");
@@ -14,7 +16,7 @@ export function sendSignupNotification(email: string, source: string): void {
 
   resend.emails
     .send({
-      from: "Menu Semanal <notificaciones@menusemanal.app>",
+      from: FROM_ADDRESS,
       to: process.env.NOTIFY_EMAIL,
       subject: `Nuevo registro en waitlist: ${email}`,
       text: [
@@ -33,4 +35,77 @@ export function sendSignupNotification(email: string, source: string): void {
       }
     })
     .catch((err) => console.error("Failed to send signup notification:", err));
+}
+
+export interface ReviewRecipient {
+  email: string;
+  name: string;
+  notificationPreferences: string | null;
+}
+
+function recipientWantsEmail(recipient: ReviewRecipient): boolean {
+  if (!recipient.notificationPreferences) return true;
+  try {
+    const prefs = JSON.parse(recipient.notificationPreferences) as {
+      email?: boolean;
+      mealPlans?: boolean;
+    };
+    return prefs.email !== false && prefs.mealPlans !== false;
+  } catch {
+    return true;
+  }
+}
+
+function formatWeekStartForDisplay(weekStartDate: string): string {
+  const [, month, day] = weekStartDate.split("-");
+  return `${day}/${month}`;
+}
+
+export function sendWeekReviewNotification(params: {
+  familyName: string;
+  weekStartDate: string;
+  submitterName: string;
+  recipients: ReviewRecipient[];
+}): void {
+  if (!resend) {
+    console.log("Email notification skipped (RESEND_API_KEY not set)");
+    return;
+  }
+
+  const optedIn = params.recipients.filter(recipientWantsEmail);
+  if (optedIn.length === 0) {
+    console.log("No recipients opted in for week review notification");
+    return;
+  }
+
+  const prettyDate = formatWeekStartForDisplay(params.weekStartDate);
+  const subject = `El menú de la semana del ${prettyDate} está listo para revisar`;
+
+  for (const recipient of optedIn) {
+    const text = [
+      `Hola ${recipient.name},`,
+      ``,
+      `${params.submitterName} terminó de planear el menú de la semana del ${prettyDate} para la familia ${params.familyName}.`,
+      ``,
+      `Abrí la app para dejar tus comentarios o proponer cambios en las comidas.`,
+      ``,
+      `— Menu Semanal`,
+    ].join("\n");
+
+    resend.emails
+      .send({
+        from: FROM_ADDRESS,
+        to: recipient.email,
+        subject,
+        text,
+      })
+      .then((result) => {
+        if (result.error) {
+          console.error(`Resend API error for ${recipient.email}:`, JSON.stringify(result.error));
+        } else {
+          console.log(`Week review notification sent to ${recipient.email}, id: ${result.data?.id}`);
+        }
+      })
+      .catch((err) => console.error(`Failed to send week review notification to ${recipient.email}:`, err));
+  }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,14 +4,14 @@ import path from "path";
 import fs from "fs";
 import crypto from "crypto";
 import { storage } from "./storage";
-import { insertRecipeSchema, insertMealPlanSchema, createFamilySchema, joinFamilySchema, insertWaitlistSignupSchema, mealPlans } from "@shared/schema";
+import { insertRecipeSchema, insertMealPlanSchema, createFamilySchema, joinFamilySchema, insertWaitlistSignupSchema, submitWeeklyReviewSchema, mealPlans } from "@shared/schema";
 import { z } from "zod";
 import { checkDatabaseHealth, db } from "./db";
 import { eq } from "drizzle-orm";
 import authRouter from "./auth/routes";
 import { apiRateLimit, familyCodeRateLimit, waitlistRateLimit, isAuthenticated, attachUser, getCurrentUser, requireCreatorRole, requireRole, requireFamilyEditAccess, commentatorRateLimit } from "./auth/middleware";
 import { generateInvitationCode, normalizeInvitationCode, isValidInvitationCodeFormat } from "@shared/utils";
-import { sendSignupNotification } from "./email";
+import { sendSignupNotification, sendWeekReviewNotification } from "./email";
 
 // Helper to parse cookies from request header (avoids adding cookie-parser dependency)
 function parseCookies(cookieHeader: string | undefined): Record<string, string> {
@@ -655,6 +655,79 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json({ message: "Plan de comida eliminado exitosamente" });
     } catch (error) {
       res.status(500).json({ error: "Error al eliminar el plan de comida" });
+    }
+  });
+
+  // Weekly review lifecycle — admin submits the week's plan for family review
+  app.get("/api/weekly-reviews", isAuthenticated, async (req, res) => {
+    try {
+      const user = getCurrentUser(req);
+      if (!user) {
+        return res.status(401).json({ error: "Usuario no autenticado" });
+      }
+
+      const weekStartDate = req.query.weekStartDate;
+      if (typeof weekStartDate !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(weekStartDate)) {
+        return res.status(400).json({ error: "Parámetro weekStartDate inválido" });
+      }
+
+      const userFamilies = await storage.getUserFamilies(user.id);
+      const familyId = userFamilies[0]?.id;
+      if (!familyId) {
+        return res.status(403).json({ error: "Debes pertenecer a una familia" });
+      }
+
+      const review = await storage.getWeeklyReview(familyId, weekStartDate);
+      res.json(review ?? null);
+    } catch (error) {
+      console.error("Error fetching weekly review:", error);
+      res.status(500).json({ error: "Error al obtener el estado de revisión" });
+    }
+  });
+
+  app.post("/api/weekly-reviews", isAuthenticated, requireCreatorRole, async (req, res) => {
+    try {
+      const user = getCurrentUser(req);
+      if (!user) {
+        return res.status(401).json({ error: "Usuario no autenticado" });
+      }
+
+      const { weekStartDate } = submitWeeklyReviewSchema.parse(req.body);
+
+      const userFamilies = await storage.getUserFamilies(user.id);
+      const family = userFamilies[0];
+      if (!family) {
+        return res.status(403).json({ error: "Debes pertenecer a una familia" });
+      }
+
+      const review = await storage.submitWeeklyReview(family.id, weekStartDate, user.id);
+
+      // Fire-and-forget email to family members (excluding the submitter)
+      const members = await storage.getFamilyMembers(family.id);
+      const recipients = members
+        .filter((m) => m.id !== user.id)
+        .map((m) => ({
+          email: m.email,
+          name: m.name,
+          notificationPreferences: m.notificationPreferences,
+        }));
+
+      if (recipients.length > 0) {
+        sendWeekReviewNotification({
+          familyName: family.nombre,
+          weekStartDate,
+          submitterName: user.name,
+          recipients,
+        });
+      }
+
+      res.status(201).json(review);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: "Datos inválidos", details: error.errors });
+      }
+      console.error("Error submitting weekly review:", error);
+      res.status(500).json({ error: "Error al enviar la semana para revisión" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -7,6 +7,8 @@ import {
   recipeRatings,
   mealComments,
   mealAchievements,
+  weeklyReviews,
+  type WeeklyReview,
   type Recipe,
   type InsertRecipe,
   type MealPlan,
@@ -85,6 +87,10 @@ export interface IStorage {
     totalStars: number,
     streakDays: number
   }>;
+
+  // Weekly review methods
+  getWeeklyReview(familyId: number, weekStartDate: string): Promise<WeeklyReview | undefined>;
+  submitWeeklyReview(familyId: number, weekStartDate: string, submittedBy: number): Promise<WeeklyReview>;
 
   // Waitlist methods
   addWaitlistSignup(email: string, source?: string): Promise<WaitlistSignup>;
@@ -375,6 +381,12 @@ export class MemStorage implements IStorage {
 
   async getUserStats(userId: number, familyId: number, startDate?: string): Promise<{ weeklyStars: { tried: number; veggie: number; feedback: number }; totalStars: number; streakDays: number }> {
     return { weeklyStars: { tried: 0, veggie: 0, feedback: 0 }, totalStars: 0, streakDays: 0 };
+  }
+
+  // Weekly review stubs
+  async getWeeklyReview(): Promise<WeeklyReview | undefined> { return undefined; }
+  async submitWeeklyReview(): Promise<WeeklyReview> {
+    throw new Error("MemStorage does not implement weekly reviews");
   }
 
   // Waitlist stubs
@@ -1091,6 +1103,49 @@ export class DatabaseStorage implements IStorage {
       streakDays,
     };
   }
+  // Weekly review methods
+  async getWeeklyReview(familyId: number, weekStartDate: string): Promise<WeeklyReview | undefined> {
+    const [review] = await db
+      .select()
+      .from(weeklyReviews)
+      .where(and(
+        eq(weeklyReviews.familyId, familyId),
+        eq(weeklyReviews.weekStartDate, weekStartDate)
+      ))
+      .limit(1);
+    return review || undefined;
+  }
+
+  async submitWeeklyReview(familyId: number, weekStartDate: string, submittedBy: number): Promise<WeeklyReview> {
+    const existing = await this.getWeeklyReview(familyId, weekStartDate);
+    const now = new Date();
+
+    if (existing) {
+      const [updated] = await db
+        .update(weeklyReviews)
+        .set({
+          submittedBy,
+          submittedAt: now,
+          status: "submitted",
+          updatedAt: now,
+        })
+        .where(eq(weeklyReviews.id, existing.id))
+        .returning();
+      return updated;
+    }
+
+    const [created] = await db
+      .insert(weeklyReviews)
+      .values({
+        familyId,
+        weekStartDate,
+        submittedBy,
+        status: "submitted",
+      })
+      .returning();
+    return created;
+  }
+
   // Waitlist methods
   async addWaitlistSignup(email: string, source: string = "landing"): Promise<WaitlistSignup> {
     const [signup] = await db

--- a/shared/__tests__/weekly-review.test.ts
+++ b/shared/__tests__/weekly-review.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  submitWeeklyReviewSchema,
+  insertWeeklyReviewSchema,
+} from "../schema";
+
+describe("submitWeeklyReviewSchema", () => {
+  it("accepts a valid YYYY-MM-DD date", () => {
+    const result = submitWeeklyReviewSchema.parse({ weekStartDate: "2026-04-20" });
+    expect(result.weekStartDate).toBe("2026-04-20");
+  });
+
+  it("rejects invalid date formats", () => {
+    expect(() => submitWeeklyReviewSchema.parse({ weekStartDate: "20-04-2026" })).toThrow();
+    expect(() => submitWeeklyReviewSchema.parse({ weekStartDate: "2026/04/20" })).toThrow();
+    expect(() => submitWeeklyReviewSchema.parse({ weekStartDate: "2026-4-20" })).toThrow();
+    expect(() => submitWeeklyReviewSchema.parse({ weekStartDate: "abc" })).toThrow();
+    expect(() => submitWeeklyReviewSchema.parse({ weekStartDate: "" })).toThrow();
+  });
+
+  it("rejects when weekStartDate is missing", () => {
+    expect(() => submitWeeklyReviewSchema.parse({})).toThrow();
+  });
+});
+
+describe("insertWeeklyReviewSchema", () => {
+  const baseRecord = {
+    familyId: 1,
+    weekStartDate: "2026-04-20",
+    submittedBy: 42,
+  };
+
+  it("accepts a valid record with status defaulted to 'submitted'", () => {
+    const result = insertWeeklyReviewSchema.parse(baseRecord);
+    expect(result.status).toBe("submitted");
+    expect(result.familyId).toBe(1);
+    expect(result.submittedBy).toBe(42);
+  });
+
+  it("accepts explicit status 'submitted'", () => {
+    const result = insertWeeklyReviewSchema.parse({ ...baseRecord, status: "submitted" });
+    expect(result.status).toBe("submitted");
+  });
+
+  it("rejects unknown status values", () => {
+    expect(() =>
+      insertWeeklyReviewSchema.parse({ ...baseRecord, status: "approved" })
+    ).toThrow();
+    expect(() =>
+      insertWeeklyReviewSchema.parse({ ...baseRecord, status: "draft" })
+    ).toThrow();
+  });
+
+  it("rejects invalid weekStartDate format", () => {
+    expect(() =>
+      insertWeeklyReviewSchema.parse({ ...baseRecord, weekStartDate: "not-a-date" })
+    ).toThrow();
+  });
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -239,6 +239,34 @@ export const mealCommentsRelations = relations(mealComments, ({ one }) => ({
   }),
 }));
 
+// Weekly review lifecycle — admin submits a week's meal plan for family review
+export const weeklyReviews = pgTable("weekly_reviews", {
+  id: serial("id").primaryKey(),
+  familyId: integer("family_id").notNull().references(() => families.id, { onDelete: "cascade" }),
+  weekStartDate: text("week_start_date").notNull(), // YYYY-MM-DD (Monday of the week)
+  status: text("status").notNull().default("submitted"), // "submitted"
+  submittedBy: integer("submitted_by").notNull().references(() => users.id, { onDelete: "cascade" }),
+  submittedAt: timestamp("submitted_at").notNull().defaultNow(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+}, (table) => {
+  return {
+    familyWeekIdx: uniqueIndex("weekly_reviews_family_week_idx").on(table.familyId, table.weekStartDate),
+    familyIdx: index("weekly_reviews_family_idx").on(table.familyId),
+  };
+});
+
+export const weeklyReviewsRelations = relations(weeklyReviews, ({ one }) => ({
+  family: one(families, {
+    fields: [weeklyReviews.familyId],
+    references: [families.id],
+  }),
+  submitter: one(users, {
+    fields: [weeklyReviews.submittedBy],
+    references: [users.id],
+  }),
+}));
+
 // Meal achievements table for kids gamification
 export const mealAchievements = pgTable("meal_achievements", {
   id: serial("id").primaryKey(),
@@ -377,6 +405,20 @@ export const insertMealAchievementSchema = createInsertSchema(mealAchievements, 
   updatedAt: true,
 });
 
+export const insertWeeklyReviewSchema = createInsertSchema(weeklyReviews, {
+  weekStartDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Fecha inválida"),
+  status: z.enum(["submitted"]).default("submitted"),
+}).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  submittedAt: true,
+});
+
+export const submitWeeklyReviewSchema = z.object({
+  weekStartDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Fecha inválida"),
+});
+
 export const awardStarSchema = z.object({
   mealPlanId: z.number().int().positive("El ID del plan de comida es requerido"),
   starType: z.enum(["tried_it", "ate_veggie", "left_feedback"], {
@@ -403,6 +445,9 @@ export type InsertMealComment = z.infer<typeof insertMealCommentSchema>;
 export type MealAchievement = typeof mealAchievements.$inferSelect;
 export type InsertMealAchievement = z.infer<typeof insertMealAchievementSchema>;
 export type AwardStarData = z.infer<typeof awardStarSchema>;
+export type WeeklyReview = typeof weeklyReviews.$inferSelect;
+export type InsertWeeklyReview = z.infer<typeof insertWeeklyReviewSchema>;
+export type SubmitWeeklyReviewData = z.infer<typeof submitWeeklyReviewSchema>;
 export type JoinFamilyData = z.infer<typeof joinFamilySchema>;
 export type CreateFamilyData = z.infer<typeof createFamilySchema>;
 


### PR DESCRIPTION
## Summary
- Adds the entry-point trigger for the family review workflow: an admin can submit a week's meal plan for family review, which sends an email to each opted-in family member.
- New `weekly_reviews` table (one row per family + week_start_date) tracks review status. Status defaults to `submitted`. Re-submit allowed.
- New API: `GET /api/weekly-reviews?weekStartDate=X` (any auth user in family) and `POST /api/weekly-reviews` (admin-only).
- New UI: "Enviar para revisión" button + confirmation dialog in the weekly calendar header (admin-only). Submitted state shows a green "Enviada hace X" pill with relative time (so it ages visibly instead of looking static).
- Email delivery extends `server/email.ts` with `sendWeekReviewNotification`, fire-and-forget per recipient, respects each user's `notificationPreferences.email` and `.mealPlans` toggles.

## What this is *not*
- No "review period" / deadline concept (per spec — open-ended).
- No proposal/swap mechanism yet (Branch 2).
- No comment surfacing on the meal card yet (Branch 3).
- No admin-side daily digest yet (Branch 4 — needs scheduler infra).

## Database
New table only — no data migration, no FK changes to existing tables. Production migration (already applied to dev):

\`\`\`sql
CREATE TABLE weekly_reviews (
  id serial PRIMARY KEY,
  family_id integer NOT NULL REFERENCES families(id) ON DELETE CASCADE,
  week_start_date text NOT NULL,
  status text NOT NULL DEFAULT 'submitted',
  submitted_by integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
  submitted_at timestamp NOT NULL DEFAULT now(),
  created_at timestamp NOT NULL DEFAULT now(),
  updated_at timestamp NOT NULL DEFAULT now()
);
CREATE UNIQUE INDEX weekly_reviews_family_week_idx ON weekly_reviews (family_id, week_start_date);
CREATE INDEX weekly_reviews_family_idx ON weekly_reviews (family_id);
\`\`\`

## Tests
- 7 new schema validation tests (`shared/__tests__/weekly-review.test.ts`)
- 6 new email-sender tests with Resend mocked (`server/__tests__/email.test.ts`)
- All 139 tests green; no new TS errors

## Test plan
- [ ] Sign in as creator/admin, plan at least one meal, click **Enviar para revisión** in calendar header → confirmation dialog → **Enviar**
- [ ] Verify toast "Semana enviada para revisión ✉️" and pill switches to **Enviada hace X min**
- [ ] Hover the pill → tooltip shows the exact submission timestamp
- [ ] Click **Reenviar** on the same week → confirmation says "La revisión anterior será reemplazada" → re-submission updates `submittedAt` and re-sends emails
- [ ] Disabled state: navigate to a week with 0 meals planned → button disabled, pill shows "Sin comidas planeadas"
- [ ] Sign in as a commentator → submit button is hidden, but the pill is visible after admin submits
- [ ] With `RESEND_API_KEY` unset → server logs "Email notification skipped"; with key set → logs "Week review notification sent to <email>"
- [ ] Recipients with `notificationPreferences.email = false` or `.mealPlans = false` are skipped (covered by unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)