### PR TITLE
Label family members by role and target review emails to Comensal users

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -301,6 +301,7 @@ interface FamilyMember {
   email: string;
   avatar?: string;
   role: "admin" | "member";
+  userRole: "creator" | "commentator";
   createdAt: string;
 }
 

--- a/client/src/pages/family-settings.tsx
+++ b/client/src/pages/family-settings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Users, Plus, UserPlus, Settings as SettingsIcon, Crown, User, Trash2, LogOut, RefreshCw, Copy } from "lucide-react";
+import { Users, Plus, UserPlus, Settings as SettingsIcon, Crown, User, Trash2, LogOut, RefreshCw, Copy, Pencil, MessageCircle } from "lucide-react";
 import { Header } from "@/components/header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -249,7 +249,7 @@ export default function FamilySettings() {
                         </Avatar>
                         
                         <div>
-                          <p className="font-medium flex items-center space-x-2">
+                          <p className="font-medium flex items-center flex-wrap gap-x-2 gap-y-1">
                             <span>{member.name}</span>
                             {member.role === "admin" && (
                               <Badge variant="secondary" className="text-xs">
@@ -257,6 +257,17 @@ export default function FamilySettings() {
                                 Admin
                               </Badge>
                             )}
+                            {member.userRole === "creator" ? (
+                              <Badge variant="outline" className="text-xs">
+                                <Pencil className="w-3 h-3 mr-1" />
+                                Planificador
+                              </Badge>
+                            ) : member.userRole === "commentator" ? (
+                              <Badge variant="outline" className="text-xs">
+                                <MessageCircle className="w-3 h-3 mr-1" />
+                                Comensal
+                              </Badge>
+                            ) : null}
                           </p>
                           <p className="text-sm text-gray-600">{member.email}</p>
                         </div>

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -272,7 +272,7 @@ export default function Register() {
                   </SelectItem>
                   <SelectItem value="commentator">
                     <div className="flex flex-col items-start">
-                      <span className="font-medium">Observador/a</span>
+                      <span className="font-medium">Comensal</span>
                       <span className="text-xs text-gray-500">Ver planes y hacer comentarios</span>
                     </div>
                   </SelectItem>

--- a/server/__tests__/family-members-roles.test.ts
+++ b/server/__tests__/family-members-roles.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for the family members API role mapping.
+ *
+ * The /api/families/:id/members endpoint returns two distinct role fields per
+ * member:
+ *  - `role`: "admin" | "member" — whether the user is the family's creator
+ *    (admin) within this specific family.
+ *  - `userRole`: "creator" | "commentator" — the user's account-level role
+ *    that determines whether they can edit plans (creator/"Planificador") or
+ *    only view and comment (commentator/"Observador").
+ *
+ * These tests validate the mapping at a behavioral level so the contract is
+ * documented even though the route handler is not directly unit-testable.
+ */
+
+type StoredMember = {
+  id: number;
+  name: string;
+  email: string;
+  avatar: string | null;
+  role: 'creator' | 'commentator';
+  createdAt: Date;
+};
+
+function mapMembersWithRoles(
+  members: StoredMember[],
+  familyCreatedBy: number | null
+) {
+  return members.map(member => ({
+    id: member.id,
+    name: member.name,
+    email: member.email,
+    avatar: member.avatar,
+    role: member.id === familyCreatedBy ? 'admin' : 'member',
+    userRole: member.role,
+    createdAt: member.createdAt,
+  }));
+}
+
+const baseMember = (overrides: Partial<StoredMember>): StoredMember => ({
+  id: 1,
+  name: 'Test User',
+  email: 'test@example.com',
+  avatar: null,
+  role: 'creator',
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+describe('Family members role mapping', () => {
+  it('marks the family creator as admin', () => {
+    const members = [baseMember({ id: 1 }), baseMember({ id: 2, email: 'b@x.com' })];
+    const mapped = mapMembersWithRoles(members, 1);
+    expect(mapped[0].role).toBe('admin');
+    expect(mapped[1].role).toBe('member');
+  });
+
+  it('exposes the user-level role (creator) as userRole', () => {
+    const members = [baseMember({ id: 5, role: 'creator' })];
+    const mapped = mapMembersWithRoles(members, 5);
+    expect(mapped[0].userRole).toBe('creator');
+  });
+
+  it('exposes the user-level role (commentator) as userRole', () => {
+    const members = [baseMember({ id: 7, role: 'commentator' })];
+    const mapped = mapMembersWithRoles(members, 1);
+    expect(mapped[0].userRole).toBe('commentator');
+  });
+
+  it('keeps admin status and userRole independent', () => {
+    // The family admin can also be a commentator-role user (edge case), and
+    // a non-admin member can be a creator-role user.
+    const members = [
+      baseMember({ id: 1, role: 'commentator' }),
+      baseMember({ id: 2, role: 'creator', email: 'c@x.com' }),
+    ];
+    const mapped = mapMembersWithRoles(members, 1);
+    expect(mapped[0]).toMatchObject({ role: 'admin', userRole: 'commentator' });
+    expect(mapped[1]).toMatchObject({ role: 'member', userRole: 'creator' });
+  });
+
+  it('handles families with no createdBy (legacy) by marking everyone as member', () => {
+    const members = [baseMember({ id: 1 }), baseMember({ id: 2, email: 'b@x.com' })];
+    const mapped = mapMembersWithRoles(members, null);
+    expect(mapped.every(m => m.role === 'member')).toBe(true);
+  });
+});

--- a/server/__tests__/weekly-review-recipients.test.ts
+++ b/server/__tests__/weekly-review-recipients.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Tests for the recipient-filter applied before sending the weekly-review
+ * notification email.
+ *
+ * The route handler at POST /api/weekly-reviews must only email family
+ * members whose user role is "commentator" (Comensal). Planificadores
+ * (creators) submit and edit plans themselves and should not receive the
+ * "enviar para revisión" email. The submitter is always excluded.
+ */
+
+type Member = {
+  id: number;
+  name: string;
+  email: string;
+  role: "creator" | "commentator";
+  notificationPreferences: string | null;
+};
+
+function filterReviewRecipients(members: Member[], submitterId: number) {
+  return members
+    .filter((m) => m.id !== submitterId && m.role === "commentator")
+    .map((m) => ({
+      email: m.email,
+      name: m.name,
+      notificationPreferences: m.notificationPreferences,
+    }));
+}
+
+const member = (overrides: Partial<Member>): Member => ({
+  id: 1,
+  name: "Member",
+  email: "m@x.com",
+  role: "creator",
+  notificationPreferences: null,
+  ...overrides,
+});
+
+describe("Weekly review recipients", () => {
+  it("only includes commentator-role members", () => {
+    const members: Member[] = [
+      member({ id: 1, role: "creator", email: "creator@x.com" }),
+      member({ id: 2, role: "commentator", email: "kid@x.com" }),
+    ];
+    const recipients = filterReviewRecipients(members, 99);
+    expect(recipients.map((r) => r.email)).toEqual(["kid@x.com"]);
+  });
+
+  it("excludes the submitter even if they are a commentator", () => {
+    // Edge case: in current product rules the submitter is always a
+    // creator (route guarded by requireCreatorRole), but the filter still
+    // excludes them defensively.
+    const members: Member[] = [
+      member({ id: 5, role: "commentator", email: "submitter@x.com" }),
+      member({ id: 6, role: "commentator", email: "other@x.com" }),
+    ];
+    const recipients = filterReviewRecipients(members, 5);
+    expect(recipients.map((r) => r.email)).toEqual(["other@x.com"]);
+  });
+
+  it("excludes other Planificador (creator) members", () => {
+    const members: Member[] = [
+      member({ id: 1, role: "creator", email: "submitter@x.com" }),
+      member({ id: 2, role: "creator", email: "other-planner@x.com" }),
+      member({ id: 3, role: "commentator", email: "kid@x.com" }),
+    ];
+    const recipients = filterReviewRecipients(members, 1);
+    expect(recipients.map((r) => r.email)).toEqual(["kid@x.com"]);
+  });
+
+  it("returns an empty list when no commentator members exist", () => {
+    const members: Member[] = [
+      member({ id: 1, role: "creator", email: "a@x.com" }),
+      member({ id: 2, role: "creator", email: "b@x.com" }),
+    ];
+    const recipients = filterReviewRecipients(members, 1);
+    expect(recipients).toEqual([]);
+  });
+
+  it("preserves notificationPreferences so downstream opt-out logic still applies", () => {
+    const members: Member[] = [
+      member({
+        id: 2,
+        role: "commentator",
+        email: "kid@x.com",
+        notificationPreferences: JSON.stringify({ email: false }),
+      }),
+    ];
+    const recipients = filterReviewRecipients(members, 1);
+    expect(recipients[0].notificationPreferences).toBe(
+      JSON.stringify({ email: false })
+    );
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -702,10 +702,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const review = await storage.submitWeeklyReview(family.id, weekStartDate, user.id);
 
-      // Fire-and-forget email to family members (excluding the submitter)
+      // Fire-and-forget email to Comensal (commentator) family members only.
+      // Planificadores (creators) can submit/edit plans themselves, so the
+      // review notification is targeted at the family members who only
+      // comment and react.
       const members = await storage.getFamilyMembers(family.id);
       const recipients = members
-        .filter((m) => m.id !== user.id)
+        .filter((m) => m.id !== user.id && m.role === "commentator")
         .map((m) => ({
           email: m.email,
           name: m.name,
@@ -884,6 +887,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         email: member.email,
         avatar: member.avatar,
         role: member.id === family?.createdBy ? "admin" : "member",
+        userRole: member.role,
         createdAt: member.createdAt
       }));
       


### PR DESCRIPTION
## Summary
- Add a Planificador/Comensal badge next to each member on `/family-settings` so admins can tell who edits plans vs. who only comments and reacts
- Rename "Observador/a" → "Comensal" in the register role picker so the same label appears wherever the role is shown
- Scope the "Enviar para revisión" email to Comensal members only (creators submit and edit plans themselves and don't need the notification)
- Add behavioral test specs covering the new role mapping in `/api/families/:id/members` and the recipient filter for weekly-review emails

## Test plan
- [ ] On `/family-settings`, each member shows their role badge (Planificador or Comensal) alongside the existing Admin badge
- [ ] On `/register`, the commentator option label reads "Comensal"
- [ ] Submitting a week for review only sends emails to commentator members; planificadores don't receive it
- [ ] `npm test` passes (new tests in `server/__tests__/family-members-roles.test.ts` and `server/__tests__/weekly-review-recipients.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)