### PR TITLE
fix: pin Claude Code Action to a current model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Model for the review (claude-sonnet-4-6 is the current Sonnet; use claude-opus-4-8 for deeper reviews)
+          model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Model for @claude (claude-sonnet-4-6 is the current Sonnet; use claude-opus-4-8 for deeper work)
+          model: "claude-sonnet-4-6"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Problem

The Claude Code Action runs (PR review + `@claude`) are failing with:

```
API Error: 404 model: claude-sonnet-4-20250514
```

The action's built-in default model (`claude-sonnet-4-20250514`) has been retired and no longer resolves, so every run dies before doing any work.

## Fix

Pin both workflows to a current model. `claude-sonnet-4-6` is the current Sonnet and the right cost tier for CI review; bump to `claude-opus-4-8` if you want deeper reviews.

- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)